### PR TITLE
Edited comment format 4

### DIFF
--- a/plugins/en/function.assign_topics_category_list.md
+++ b/plugins/en/function.assign_topics_category_list.md
@@ -1,22 +1,18 @@
-<?php
- /**
- *  Smarty {assign_topics_category_list} function plugin
- *  --------------------------------
- *  Author: 金川 正樹 <kanagawa@diverta.co.jp>
- *  Purpose: 指定されたカテゴリに紐付くトピックをリストにして返す
- *  Purpose Eng: Returns the associated categories from an specific topics_group_id
- *               (returns only published topics categories)
- *  Params :
- *      'var': String -- assignする変数名(必須)
- *      'topics_group_id': Integer -- カテゴリ群のtopics_group_idを指定する(必須)
- *      'lang': String -- 言語設定
- *
- *  Params Eng:
- *      'var': String -- assign output variable (required)
- *      'topics_group_id': Integer -- topics_group_id of a specific list of topics categories (required)
- *      'lang': String -- Language code (optional)
- *      * All the parameters acepted by RCMSAction::factory() can also be inserted
- *
- *  Usage: 使用例:
- *      {assign_topics_category_list topics_group_id=1 var='topics_category_list'}
- **/
+## Smarty {assign_topics_category_list} function plugin
+
+### Purpose:
+Returns the associated categories from an specific topics_group_id
+
+(returns only published topics categories)
+
+### Params:
+Param | Type | Description
+--- | --- | ---
+var | String | assign output variable (required)
+topics_group_id | Integer | topics_group_id of a specific list of topics categories (required)
+lang | String | Language code (optional)
+
+All the parameters acepted by RCMSAction::factory() can also be inserted
+
+### Usage:
+{assign_topics_category_list topics_group_id=1 var='topics_category_list'}

--- a/plugins/en/function.assign_topics_detail.md
+++ b/plugins/en/function.assign_topics_detail.md
@@ -1,27 +1,17 @@
-<?php
-/**
- *  Smarty {assign_topics_detail} function plugin
- *  --------------------------------
- *  Author: 金川 正樹 <kanagawa@diverta.co.jp>
- *  Purpose: 指定されたトピックスの詳細情報を返す
- *  Purpose Eng: Returns the details from an specific topics
- *
- *  Params :
- *      (必須)'var': String -- assignする変数名
- *      (必須)'topics_id': Integer -- トピックスのID
- *      'id': Integer -- トピックスのID(topics_idまたはidのいずれか1つを指定する. 両方あった場合はtopics_idの値が優先される)
- *      'lang': String -- 言語設定
- *      'print': Boolean -- トピックスの詳細情報の出力に関するフラグ(1で表示)
- *      'no_ext_column_flg': Boolean -- 追加カラムの表示に関するフラグ(1で非表示)
- *
- *  Params Eng:
- *      'var': String -- assign output variable (required)
- *      'topics_id': Integer -- topics id to get the details from (required)
- *      'id': Integer -- the same as 'topics_id' (if no 'topics_id', required)
- *      'lang': String -- Language code (optional)
- *      'print': Boolean --  if true, prints the function output (optional)
- *      'no_ext_column_flg': Boolean -- if true, no extra columns are not included
- *
- *  Usage: 使用例:
- *      {assign_topics_detail topics_id=100 var='topics_data'}
- **/
+## Smarty {assign_topics_detail} function plugin
+
+### Purpose:
+Returns the details from an specific topics
+
+### Params:
+Param | Type | Description
+--- | --- | ---
+var | String | assign output variable (required)
+topics_id | Integer | topics id to get the details from (required)
+id | Integer | the same as 'topics_id' (if no 'topics_id', required)
+lang | String | Language code (optional)
+print | Boolean |  if true, prints the function output (optional)
+no_ext_column_flg | Boolean | if true, no extra columns are not included
+
+### Usage:
+{assign_topics_detail topics_id=100 var='topics_data'}

--- a/plugins/en/function.assign_topics_ext.md
+++ b/plugins/en/function.assign_topics_ext.md
@@ -1,57 +1,33 @@
-<?php
+## Smarty {assign_topics_ext} function plugin
 
-/**
- *  Smarty {assign_topics_ext}{/assign_topics_ext} function plugin
- *  --------------------------------
- *  Author: Masaki Kanagawa <kanagawa@diverta.co.jp>
- *  Purpose: 記事の拡張項目の値を取得する
- *  Purpose Eng: Retrives the extended items value from a topic
- *
- *   Params : 
- *      'topics_id': Integer  -- トピックスID. (必須)
- *      'row_value': Object   -- topics_headerのデータベースの行のオブジェクト. 予め拡張項目の値が格納されています.
- *      'ext_data': Object    -- 各トピックスと紐づいた拡張項目の値のオブジェクト
- *      'ext_type': String    -- 出力したい外部カラムの形式. (必須) (例: 'group' )
- *      'var': String         -- アサインする変数の名前. (必須)
- *      'id': Integer         -- 紐づいている拡張項目のID. (必須)
- *      'ext_columns':Array   -- 拡張項目のカラムの返り値. (必須)
- *      'ext_group_sort':Array -- 返り値の型を特定する配列. 
- *      'array_ext_type':String -- 出力したい配列の型.
- *      'separator': String   -- 複数のデータを区切るデリミタ.
- *      'pieces': String      -- 'separator'と同じ. ('separator'の指定がある場合は'separator'が優先されます)
- *      'parent_key': Integer -- データと紐づいている親キー.
- *      'print': Boolean      -- 真(==1)の場合, 値を表示する.
- *      'return_flg': Boolean -- 真(==1)になった時に, 変数をアサインして結果を返すフラグ.
- *      'no_ext_column_flg': Boolean -- 真(==1)の場合, 拡張項目に関するトピックスが含まれなくなる.
- *      'lang': String        -- 言語コード
- *      'decimals': Integer   -- ファイル容量の優先度
- *      'height': Integer     -- 埋め込み表示するスクリプトの高さを指定する(デフォルト: 480)
- *      'width': Integer      -- 埋め込み表示するスクリプトの幅を指定する(デフォルト: 360)
- *      'default': String     -- デフォルト値を設定する
- *
- *  Params (Eng): 
- *      'topics_id': Integer  -- topics id to get the data (required)
- *      'row_value': Object   -- topics_header db row object, used to get the extended data　
- *      'ext_data': Object    -- The direct extended data of each topic
- *      'ext_type': String    -- Specific external column type to be return (required ex.'group')
- *      'var': String         -- assigned output variable name (required)
- *      'id': Integer         -- The id of specific related extended data (required)
- *      'ext_columns':Array   -- Specific extended columns to be returned (required)
- *      'ext_group_sort':Array -- Array to specify the results order (optional)
- *      'array_ext_type':String -- Specific array type to be return (optional)
- *      'separator': String   -- Separator for multiple selection data (optional)
- *      'pieces': String      -- Same as 'separator', used only if no 'separator' (optional) 
- *      'parent_key': Integer -- Returns data only if it is related with this Parent key (optional)
- *      'print': Boolean      -- If true, prints the function output (optional)
- *      'return_flg': Boolean -- If true, assign and performs a return (optional)
- *      'no_ext_column_flg': Boolean -- If true, do not obtain the topics extended columns (optional)
- *      'lang': String        -- Language code (optional)
- *      'decimals': Integer   -- The image file size precision in number of decimals (optional)   
- *      'height': Integer     -- Sets the video player height (optional - default=480)
- *      'width': Integer      -- Sets the video player width (optional - default=360)
- *      'default': String     -- Set default value
- *
- *  Usage: 使用例:
- *      {assign_topics_ext ext_columns=$row.ext_columns id='02' ext_type='url' var='value'}
- *      {assign_topics_ext ext_columns=$extensions_config row_value=$row id='01' ext_type='value'  var=ext01}
-**/
+### Purpose:
+Retrives the extended items value from a topic
+
+### Params:
+Param | Type | Description
+--- | --- | ---
+topics_id | Integer | topics id to get the data (required)
+row_value | Object | topics_header db row object, used to get the extended data
+ext_data | Object | The direct extended data of each topic
+ext_type | String | Specific external column type to be return (required ex.'group')
+var | String | assigned output variable name (required)
+id | Integer | The id of specific related extended data (required)
+ext_columns | Array | Specific extended columns to be returned (required)
+ext_group_sort | Array | Array to specify the results order (optional)
+array_ext_type | String | Specific array type to be return (optional)
+separator | String | Separator for multiple selection data (optional)
+pieces | String | Same as 'separator', used only if no 'separator' (optional)
+parent_key | Integer | Returns data only if it is related with this Parent key (optional)
+print | Boolean | If true, prints the function output (optional)
+return_flg | Boolean | If true, assign and performs a return (optional)
+no_ext_column_flg | Boolean | If true, do not obtain the topics extended columns (optional)
+lang | String | Language code (optional)
+decimals | Integer | The image file size precision in number of decimals (optional)
+height | Integer | Sets the video player height (optional - default=480)
+width | Integer | Sets the video player width (optional - default=360)
+default | String | Set default value
+
+### Usage:
+{assign_topics_ext ext_columns=$row.ext_columns id='02' ext_type='url' var='value'}
+
+{assign_topics_ext ext_columns=$extensions_config row_value=$row id='01' ext_type='value' var=ext01}

--- a/plugins/en/function.assign_topics_list.md
+++ b/plugins/en/function.assign_topics_list.md
@@ -1,17 +1,9 @@
-<?php
-/**
- *  Smarty {assign_topics_list} function plugin
- *  --------------------------------
- *  Author;     金川 正樹 <kanagawa@diverta.co.jp>
- *  Purpose:     
- *  Purpose Eng: 
- *               
- *  Params : 
- *      'var': String -- assignする変数名 (必須)    
- *                               
- *  Params Eng: 
- *      'var': String -- assign output variable (required) 
- *      
- *  Usage: 使用例:
- *      {assign_topics_list topics_group_id=1 cnt=10 var='topics_list'}
- **/
+## Smarty {assign_topics_list} function plugin
+
+### Params:
+Param | Type | Description
+--- | --- | ---
+var | String | assign output variable (required)
+
+### Usage:
+{assign_topics_list topics_group_id=1 cnt=10 var='topics_list'}

--- a/plugins/en/function.batch.md
+++ b/plugins/en/function.batch.md
@@ -1,18 +1,10 @@
-<?php
-/**
- *  Smarty {batch} function plugin
- *  --------------------------------
- *  Purpose: APIをリクエストして、応答をassignする
- *  Purpose Eng: Request API internally and assign response
- *
- *  Params :
- *      'batch_id': バッチID(必須)
- *      'ext_data': データ 
- *
- *  Params Eng:
- *      'batch_id': batch_id(required)
- *      'ext_data': data
- *
- *  Usage: 使用例:
- *      {batch batch_id='1234' ext_data=$ext_data}
- **/
+## Smarty {batch} function plugin
+
+### Params:
+Param | Description
+--- | ---
+batch_id | batch_id(required)
+ext_data | data
+
+### Usage:
+{batch batch_id='1234' ext_data=$ext_data}


### PR DESCRIPTION
### やったこと
PHPのコメントからMD形式に変更

* plugins/en/function.assign_topics_list.md
Usage で使われている topics_group_id や cnt が Params に書かれていない点が気になりましたが、ひとまず内容の修正はせず表示形式の変更だけに留めました。

* plugins/en/function.batch.md
Purpose の内容が明らかに実際の処理と一致していないため、削除しました。
（おそらく plugins/en/function.api.md からのコピペがそのまま残っているものと思われます）

### レビュアー
@KentaKatoh 
ご確認をお願いいたします。