### PR TITLE
Edited comment format 5

### DIFF
--- a/plugins/en/function.date.md
+++ b/plugins/en/function.date.md
@@ -1,22 +1,16 @@
-<?php
- /**
- *  Smarty {date}{/date} function plugin
- *  --------------------------------
- *  Purpose:     日付に関する変数をassign
- *  Purpose Eng: Assigns variable on date
- * 
- *  Params : 
- *      'var': String     -- assignする変数名 (必須) 
- *      'time': String    -- strtotime フォーマット
- *      'format': String    -- フォーマット
- *      
- *  Params Eng: 
- *      'var': String     -- assign output variable (required) 
- *      'time': String    -- strtotime format
- *      'format': String    -- format
+## Smarty {date} function plugin
 
- *  
- *  Usage: 使用例:
- *  {date var=yesterday  time='Yesterday'  format='Y-m-d'}
- *  {date var=today format='Y-m-d H:i:s'}
- **/
+### Purpose:
+Assigns variable on date
+
+### Params:
+Param | Type | Description
+--- | --- | ---
+var | String | assign output variable (required)
+time | String | strtotime format
+format | String | format
+
+### Usage:
+{date var=yesterday  time='Yesterday'  format='Y-m-d'}
+
+{date var=today format='Y-m-d H:i:s'}

--- a/plugins/en/function.get_file.md
+++ b/plugins/en/function.get_file.md
@@ -1,20 +1,14 @@
-<?php
-/**
- *  Smarty {get_file} function plugin
- *  --------------------------------
- *  Purpose: ファイルを取得する
- *  Purpose Eng: Move file
- *
- *  Params :
- *      'var':
- *      'path':
- *      'url':
- *
- *  Params Eng:
- *      'var':
- *      'path':
- *      'url':
- *
- *  Usage: 使用例:
- *      {get_file path=$path}
- **/
+## Smarty {get_file} function plugin
+
+### Purpose:
+Move file
+
+### Params:
+Param |
+--- |
+var |
+path |
+url |
+
+### Usage
+{get_file path=$path}

--- a/plugins/en/function.include_block.md
+++ b/plugins/en/function.include_block.md
@@ -1,7 +1,1 @@
-<?php
-/**
- * Smarty plugin
- * @category CMS
- * @package  Smarty
- * @author   Kenta Katoh <kenta@diverta.co.jp>
- */
+## Smarty {include_block} function plugin

--- a/plugins/en/function.logger.md
+++ b/plugins/en/function.logger.md
@@ -1,20 +1,14 @@
-<?php
-/**
- *  Smarty {logger} function plugin
- *  --------------------------------
- *  Purpose: info.logに記録する
- *  Purpose Eng: Record in info.log
- *
- *  Params :
- *      'msg1': 文字列1
- *      'msg2': 文字列2
- *      'msg3': 文字列3
- *
- *  Params Eng:
- *      'msg1': String1
- *      'msg2': String2
- *      'msg3': String3
- *
- *  Usage: 使用例:
- *      {logger msg1=$log1 msg2=$log2}
- **/
+## Smarty {logger} function plugin
+
+### Purpose:
+Record in info.log
+
+### Params:
+Param | Description
+--- | ---
+msg1 | String1
+msg2 | String2
+msg3 | String3
+
+### Usage:
+{logger msg1=$log1 msg2=$log2}

--- a/plugins/en/function.put_file.md
+++ b/plugins/en/function.put_file.md
@@ -1,18 +1,13 @@
-<?php
-/**
- *  Smarty {put_file} function plugin
- *  --------------------------------
- *  Purpose: ファイルをアップロードする
- *  Purpose Eng: Move file
- *
- *  Params :
- *      'tmp_path': 一時ファイルパス
- *      'path': アップロード先パス
- *
- *  Params Eng:
- *      'tmp_path': temp path
- *      'path': upload path
- *
- *  Usage: 使用例:
- *      {put_file tmp_path=$tmp_path path=$upload_path}
- **/
+## Smarty {put_file} function plugin
+
+### Purpose:
+Move file
+
+### Params:
+Param | Description
+--- | ---
+tmp_path | temp path
+path | upload path
+
+### Usage: 使用例:
+{put_file tmp_path=$tmp_path path=$upload_path}

--- a/plugins/en/function.put_file.md
+++ b/plugins/en/function.put_file.md
@@ -9,5 +9,5 @@ Param | Description
 tmp_path | temp path
 path | upload path
 
-### Usage: 使用例:
+### Usage:
 {put_file tmp_path=$tmp_path path=$upload_path}


### PR DESCRIPTION
### やったこと
PHPのコメントからMD形式に変更

* plugins/en/function.get_file.md
Params の内容が書かれていませんでしたが、ひとまず表形式で表示するように修正しました。

* plugins/en/function.include_block.md
元のコメントが少なく、MDに残りませんでしたが、h2 は他のプラグインに倣って記入しました。

### レビュアー
@KentaKatoh 
ご確認をお願いいたします。