### PR TITLE
Edited comment format 7

### DIFF
--- a/plugins/en/modifier.json_decode.md
+++ b/plugins/en/modifier.json_decode.md
@@ -1,8 +1,1 @@
-<?php
-/**
- * Smarty plugin
- * @category CMS
- * @package  Smarty
- * @author   牛田　聖嗣 <ushida@diverta.co.jp>
- * json_decodeを使う際に、smarty上でのjson_decodeの記述を省くためのプラグイン
- */
+## Smarty json_decode modifier plugin

--- a/plugins/en/modifier.mbtruncate.md
+++ b/plugins/en/modifier.mbtruncate.md
@@ -1,4 +1,1 @@
-<?php
-function smarty_modifier_mbtruncate($string, $length = 80, $etc = '...') {
-    return rcms_mbtruncate($string, $length, $etc);
-}
+## Smarty mbtruncate modifier plugin

--- a/plugins/en/modifier.rcms_arsort.md
+++ b/plugins/en/modifier.rcms_arsort.md
@@ -1,10 +1,4 @@
-<?php
-/**
- * Smarty plugin
- * @category CMS
- * @package  Smarty
- * @author   Yoshinobu Terashima <terashima@diverta.co.jp>
- * 連想キーと要素との関係を維持しつつ配列を逆順にソートする
- * 注意：配列に対する修飾子になるので、@をつける必要があります。
- * [usage]  {assign var="result_arr" value=$input_arr|@rcms_arsort}
- */
+## Smarty rcms_arsort modifier plugin
+
+### Usage:
+{assign var="result_arr" value=$input_arr|@rcms_arsort}

--- a/plugins/en/modifier.rcms_asort.md
+++ b/plugins/en/modifier.rcms_asort.md
@@ -1,10 +1,4 @@
-<?php
-/**
- * Smarty plugin
- * @category CMS
- * @package  Smarty
- * @author   Yoshinobu Terashima <terashima@diverta.co.jp>
- * 連想キーと要素との関係を維持しつつ配列をソートする
- * 注意：配列に対する修飾子になるので、@をつける必要があります。
- * [usage]  {assign var="result_arr" value=$input_arr|@rcms_asort}
- */
+## Smarty rcms_asort modifier plugin
+
+### Usage:
+{assign var="result_arr" value=$input_arr|@rcms_asort}

--- a/plugins/en/modifier.rcms_file_exists.md
+++ b/plugins/en/modifier.rcms_file_exists.md
@@ -1,18 +1,10 @@
-<?php
-/**
- * Smarty plugin
- * @package Smarty
- * @subpackage plugins
- */
+## Smarty rcms_file_exists modifier plugin
 
+### Purpose:
+get file exists
 
-/**
- * Smarty rcms_file_exists modifier plugin
- *
- * Type:     modifier<br>
- * Name:     rcms_file_exists<br>
- * Purpose:  get file exists
- * @author   RCMS
- * @param string
- * @return int
- */
+### Param:
+string
+
+### Return:
+int


### PR DESCRIPTION
### やったこと
PHPのコメントからMD形式に変更

全体的に元のコメントが少なく、MDに残りませんでしたが、h2 は他のプラグインに倣って記入しました。

### レビュアー
@KentaKatoh 
ご確認をお願いいたします。